### PR TITLE
Set encoding of output file to be utf-8

### DIFF
--- a/code/SEntiMoji_script/classify.py
+++ b/code/SEntiMoji_script/classify.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     else:
         pred_y = np.argmax(pred_y_prob, axis=1)
     
-    with open(save_path, "w") as f:
+    with open(save_path, "w", encoding="utf-8") as f:
         for i in range(0, len(test_text)):
             f.write("{}\t{}\r\n".format(test_text[i], pred_y[i]))
     


### PR DESCRIPTION
By setting the encoding of the output file to be utf-8, it allows for emojis and other special characters found in the text to be written to the output file. Currently, a "UnicodeEncodeError: 'charmap' codec can't encode character..." error is thrown if attempting to run classify.py on text containing Unicode characters.